### PR TITLE
Missing AC127-050-A-ML

### DIFF
--- a/table_of_parts_xopenspim.md
+++ b/table_of_parts_xopenspim.md
@@ -243,7 +243,7 @@ Some self-made parts, including an X-OpenSPIM acquisition chamber, can be purcha
 <td align="center">Cylindrical Achromat Lens</td>
 <td align="center"> <a href="https://www.thorlabs.de/thorproduct.cfm?partnumber=ACY254-050-A">ACY254-050-A</a></td>
 <td align="center"><img src="images/ACY254-050-A.jpeg" width="150"></td>
-<td align="center">1</td>
+<td align="center">2</td>
 <td align="center">369,85 €</td>
 </tr>
 


### PR DESCRIPTION
Need to mention that 2 are needed? Check with Johannes. Put temporarily a qtty 2 on the ACY254-050-A, but should be AC127-050-A-ML.